### PR TITLE
initialize BPM with cached value from SubmissionModal

### DIFF
--- a/src/components/SubmissionModal.tsx
+++ b/src/components/SubmissionModal.tsx
@@ -20,10 +20,12 @@ interface Props {
 }
 
 function SubmissionModal({ open, playlist, onClose, onNo }: Props) {
+  const cachedBpm = getCurrentBPM()
+
+  const [bpm, setBpm] = useState<BPM>({ max: cachedBpm["max"], min: cachedBpm["min"] })
   const [submissionState, setSubmissionState] = useState<SubmissionState>("bpm")
   const [createdPlaylist, setCreatedPlaylist] = useState<Playlist>()
   const [tracks, setTracks] = useState<Track[]>([])
-  const [bpm, setBpm] = useState<BPM>({ max: 260, min: 60 })
 
   // For cancelling api calls that are no longer needed
   const playlistItemCalls = useRef<ApiCall<PlaylistItem[]>[]>([])


### PR DESCRIPTION
Addressing [this issue](https://github.com/alexthescott/Sprintify/issues/54)

Super simple change that alters the initialization of BPM from the SubmissionModal to use cached values. Previously the valid BPM values were displayed but not used until set until onChange() was called 